### PR TITLE
Align ZIP

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -80,7 +80,6 @@ java -jar bin/uber-apk-signer-1.2.1.jar -a $DEXCOM_MOD_APK \
 --ksAlias cert \
 --ksPass $KEYSTORE_PASS \
 --ksKeyPass $KEYSTORE_PASS \
---skipZipAlign \
 --overwrite
 checkStatus $?
 echo "----------------------";

--- a/bin/dev-build.sh
+++ b/bin/dev-build.sh
@@ -25,7 +25,6 @@ java -jar bin/uber-apk-signer-1.2.1.jar -a $DEXCOM_MOD_APK \
 --ksAlias cert \
 --ksPass $KEYSTORE_PASS \
 --ksKeyPass $KEYSTORE_PASS \
---skipZipAlign \
 --overwrite
 checkStatus $?
 echo "----------------------";


### PR DESCRIPTION
Otherwise it results in an uninstallable APK

% adb install dexcom.patched.apk
Performing Streamed Install
adb: failed to install dexcom.patched.apk: Failure [-124: Failed parse during installPackageLI: Targeting R+ (version 30 and above) requires the resources.arsc of installed APKs to be stored uncompressed and aligned on a 4-byte boundary]