### PR TITLE
Fix for not updating the docker image

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 rm -rf dexcom.patched.apk
-docker build -t diakem-dexcom-g7-apk-patcher .
+docker build --no-cache -t diakem-dexcom-g7-apk-patcher .
 docker run -it -v $(pwd):/output diakem-dexcom-g7-apk-patcher 


### PR DESCRIPTION
Enforces full download of the docker image to avoid issues with changes to the scripts.
Fixes https://github.com/DiaKEM/dexcom-g7-apk-patcher/issues/30