### PR TITLE
Pin upstream APK to version in docker environment

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -2,6 +2,6 @@
 
 wget  --user-agent='Mozilla/5.0' \
       -O dexcom.stock.apk \
-      https://d.apkpure.com/b/APK/com.dexcom.g7?version=latest
+      https://d.apkpure.com/b/APK/com.dexcom.g7?versionCode=4537
 bin/build.sh ./dexcom.stock.apk
 mv dexcom.patched.apk /output


### PR DESCRIPTION
This pins the APK version to `1.6.1.4537`.

Apparently newer versions of the Dexcom app do not support this patching.